### PR TITLE
Added CentOS 7 and Ubuntu 14/16 compatilibity and enabled option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,4 +21,10 @@ Available states
 Installs the supervisor package, and starts the associated supervisor programs.
 
 
-Currently only tested on Debian, needs package information etc for other OS.
+Tested on Debian, Ubuntu 14, Ubuntu 16 and CentOS 7. CentOS 6 doesn't work.
+
+Warning
+=======
+
+This formula works with supervisor version 3. It does NOT work with v2 so it doesn't work with CentOS 6 (repo version is v2).
+

--- a/pillar.example
+++ b/pillar.example
@@ -2,8 +2,10 @@
 # Example pillar configuration
 #
 supervisor:
+  legacy: False # Just to use the my-app-prog.conf program name (legacy: True, by default) or just my-app.conf (legacy: False)
   programs:
     my-app:
+      enabled: True # The program.conf can be removed with this variable
       autorestart: 'true'
       autostart: 'true'
       redirect_stderr: 'true'

--- a/supervisor/config.sls
+++ b/supervisor/config.sls
@@ -16,11 +16,16 @@ supervisor-config:
     - watch_in:
       - service: supervisor.service
 
-{% if 'programs' in supervisor -%}
-{% for program,values in supervisor.programs.items() -%}
+{% if 'programs' in supervisor %}
+{% for program,values in supervisor.programs.items() %}
 supervisor-program-{{ program }}:
+{% if ( 'enabled' in values and values.enabled ) or 'enabled' not in values %}
   file.managed:
+{% if 'legacy' in supervisor and supervisor.legacy %}
     - name: {{ supervisor.program_dir }}/{{ program }}-prog.conf
+{% else %}
+    - name: {{ supervisor.program_dir }}/{{ program }}.conf
+{% endif %}
     - source: salt://supervisor/templates/program.conf.tmpl
     - template: jinja
     - mode: 644
@@ -31,6 +36,17 @@ supervisor-program-{{ program }}:
         values: {{ values }}
     - watch_in:
       - service: supervisor.service
-{% endfor -%}
-{% endif -%}
+{% elif 'enabled' in values and not values.enabled %}
+  file.absent:
+{% if 'legacy' in supervisor and supervisor.legacy %}
+    - name: {{ supervisor.program_dir }}/{{ program }}-prog.conf
+{% else %}
+    - name: {{ supervisor.program_dir }}/{{ program }}.conf
+{% endif %}
+    - watch_in:
+        - service: supervisor.service
+{% endif %}
+
+{% endfor %}
+{% endif %}
 

--- a/supervisor/defaults.yaml
+++ b/supervisor/defaults.yaml
@@ -1,22 +1,4 @@
 # -*- coding: utf-8 -*-
 # vim: ft=yaml
 supervisor:
-  pkg: supervisor
-  config: '/etc/supervisor/supervisord.conf'
-  program_dir: '/etc/supervisor/conf.d'
-  service:
-    name: supervisor
-  supervisord_conf:
-    unix_http_server:
-      file: '/var/run/supervisor.sock'
-      chmod: '0700'
-    supervisord:
-      logfile: '/var/log/supervisor/supervisord.log'
-      pidfile: '/var/run/supervisord.pid'
-      childlogdir: '/var/log/supervisor'
-    include:
-      files: '/etc/supervisor/conf.d/*.conf'
-    'rpcinterface:supervisor':
-      supervisor.rpcinterface_factory: 'supervisor.rpcinterface:make_main_rpcinterface'
-    supervisorctl:
-      serverurl: 'unix:///var/run/supervisor.sock'
+  legacy: True

--- a/supervisor/install.sls
+++ b/supervisor/install.sls
@@ -3,6 +3,13 @@
 
 {% from "supervisor/map.jinja" import supervisor with context %}
 
+{% if grains['os_family'] == 'RedHat' %}
+
+include:
+    - epel
+
+{% endif %}
+
 supervisor-pkg:
   pkg.installed:
     - name: {{ supervisor.pkg }}

--- a/supervisor/map.jinja
+++ b/supervisor/map.jinja
@@ -1,28 +1,74 @@
 # -*- coding: utf-8 -*-
 # vim: ft=jinja
 
-{## Start with  defaults from defaults.sls ##}
 {% import_yaml 'supervisor/defaults.yaml' as default_settings %}
 
-{##
-Setup variable using grains['os_family'] based logic, only add key:values here
-that differ from whats in defaults.yaml
-##}
 {% set os_family_map = salt['grains.filter_by']({
         'Debian': {
-            "pkg" : 'supervisor',
+            'pkg' : 'supervisor',
+            'config': '/etc/supervisor/supervisord.conf',
+            'program_dir': '/etc/supervisor/conf.d',
+            'service' : {
+                'name': 'supervisor',
+            },
+            'supervisord_conf': {
+                'unix_http_server': {
+                    'file': '/var/run/supervisor.sock',
+                    'chmod': '0700',
+                },
+                'supervisord': {
+                    'logfile': 'var/log/supervisor/supervisord.log',
+                    'pidfile': '/var/run/supervisord.pid',
+                    'childlogdir': '/var/log/supervisor',
+                },
+                'rpcinterface:supervisor': {
+                    'supervisor.rpcinterface_factory': 'supervisor.rpcinterface:make_main_rpcinterface',
+                },
+                'supervisorctl': {
+                    'serverurl': 'unix:///var/run/supervisor.sock',
+                },
+                'include': {
+                    'files': '/etc/supervisor/conf.d/*.conf',
+                },
+            },
         },
         'Suse'  : {},
         'Arch'  : {},
-        'RedHat': {},
+        'RedHat': {
+            'pkg' : 'supervisor',
+            'config': '/etc/supervisord.conf',
+            'program_dir': '/etc/supervisord.d',
+            'service' : {
+                'name': 'supervisord',
+            },
+            'supervisord_conf': {
+                'unix_http_server': {
+                    'file': '/var/run/supervisor/supervisor.sock',
+                    'chmod': '0700',
+                },
+                'supervisord': {
+                    'logfile': 'var/log/supervisor/supervisord.log',
+                    'pidfile': '/var/run/supervisord.pid',
+                    'childlogdir': '/var/log/supervisor',
+                },
+                'rpcinterface:supervisor': {
+                    'supervisor.rpcinterface_factory': 'supervisor.rpcinterface:make_main_rpcinterface',
+                },
+                'supervisorctl': {
+                    'serverurl': 'unix:///var/run/supervisor/supervisor.sock',
+                },
+                'include': {
+                    'files': 'supervisord.d/*.conf',
+                },
+            },
+        },
   }
   , grain="os_family"
   , merge=salt['pillar.get']('supervisor:lookup'))
 %}
-{## Merge the flavor_map to the default settings ##}
+
 {% do default_settings.supervisor.update(os_family_map) %}
 
-{## Merge in supervisor:lookup pillar ##}
 {% set supervisor = salt['pillar.get'](
         'supervisor',
         default=default_settings.supervisor,

--- a/supervisor/templates/program.conf.tmpl
+++ b/supervisor/templates/program.conf.tmpl
@@ -1,6 +1,8 @@
 ;;; File managed by Salt
-[program:{{ program }}]
-{% for key, value in values.items() -%}
-{{ key }}={{ value }}
-{% endfor -%}
 
+[program:{{ program }}]
+{%- for key, value in values.items() -%}
+{%- if 'enabled' not in key %}
+{{ key }}={{ value }}
+{%- endif -%}
+{% endfor -%}

--- a/supervisor/templates/supervisord.conf.tmpl
+++ b/supervisor/templates/supervisord.conf.tmpl
@@ -7,6 +7,5 @@
 [{{ key }}]
 {% for k, v in value.items() -%}
 {{ k }}={{ v }}
+{% endfor %}
 {% endfor -%}
-{% endfor -%}
-


### PR DESCRIPTION
- Added CentOS 7 and Ubuntu 14/16 compatibility
- Added an option (enabled: True/False) to be able to remove programs files
- Added an option (legacy: True/False) to keep or remove the old program naming schema (my-app-prog.conf)
- Remove some superfluous information
- Added more documentation